### PR TITLE
Migrate NotificationService to current Bare Kit API

### DIFF
--- a/app/NotificationService.swift
+++ b/app/NotificationService.swift
@@ -1,11 +1,34 @@
 import BareKit
+import UserNotifications
 
-class NotificationService: BareKit.NotificationService {
-  override init() {
-    super.init(
-      resource: "push", ofType: "bundle",
-      configuration: Worklet.Configuration(
-        memoryLimit: 8 * 1024 * 1024
-      ))
+class NotificationService: UNNotificationServiceExtension {
+  private let worklet = Worklet(
+    configuration: Worklet.Configuration(memoryLimit: 8 * 1024 * 1024))
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    worklet.start(name: "push", ofType: "bundle")
+
+    let content =
+      (request.content.mutableCopy() as? UNMutableNotificationContent)
+      ?? UNMutableNotificationContent()
+
+    let payload = try? JSONSerialization.data(withJSONObject: request.content.userInfo)
+
+    Task {
+      defer { worklet.terminate() }
+
+      if let payload,
+        let reply = try? await worklet.push(data: payload),
+        let fields = try? JSONSerialization.jsonObject(with: reply) as? [String: Any]
+      {
+        if let title = fields["title"] as? String { content.title = title }
+        if let body = fields["body"] as? String { content.body = body }
+      }
+
+      contentHandler(content)
+    }
   }
 }


### PR DESCRIPTION
`bare-kit-swift` removed the `BareKit.NotificationService` class ([`ef26bbd`](https://github.com/holepunchto/bare-kit-swift/commit/ef26bbd)). Since `project.yml` tracks its `main` branch, that broke the build:

```
no type named 'NotificationService' in module 'BareKit'
```

Reimplement the extension against the surviving API: subclass `UNNotificationServiceExtension` and drive a `Worklet` directly — start the `push` bundle, push the payload (firing `BareKit.on('push')`), apply the reply's title/body. This is what the removed class did internally.

Verified with `xcodebuild -scheme App ... build` → **BUILD SUCCEEDED**.

Note: `serviceExtensionTimeWillExpire()` is intentionally not overridden — a hung worklet falls back to the original notification. Fine for a reference example.